### PR TITLE
Fix LocalDb databases with missing files

### DIFF
--- a/tests/DbTestMonkey.NUnit.Tests/App.config
+++ b/tests/DbTestMonkey.NUnit.Tests/App.config
@@ -34,6 +34,10 @@
       <sqlServer 
          isLocalDbInstance="true"
          localDbInstanceName="DbTestMonkey">
+        <allowedLocalDbVersions>
+          <version>11.0</version>
+          <version>12.0</version>
+        </allowedLocalDbVersions>
          <databases>
             <database 
                databaseName="TestDatabase1" 

--- a/tests/DbTestMonkey.XUnit.Tests/App.config
+++ b/tests/DbTestMonkey.XUnit.Tests/App.config
@@ -34,6 +34,10 @@
       <sqlServer 
          isLocalDbInstance="true"
          localDbInstanceName="DbTestMonkey">
+        <allowedLocalDbVersions>
+          <version>11.0</version>
+          <version>12.0</version>
+        </allowedLocalDbVersions>
          <databases>
             <database 
                databaseName="TestDatabase1" 


### PR DESCRIPTION
When a LocalDb server still logically existed but the physical files
were missing it would cause deployments to fail. Now if there are
any physical files missing they are all deleted along with the LocalDb
instance and recreated.