### PR TITLE
Fix NUnit working directory and DbTestMonkey project build order

### DIFF
--- a/DbTestMonkey.sln
+++ b/DbTestMonkey.sln
@@ -44,6 +44,9 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DbTestMonkey.NUnit.Fody", "src\DbTestMonkey.NUnit.Fody\DbTestMonkey.NUnit.Fody.csproj", "{C901325C-6AAF-4E33-B2A7-7F2079AE3F21}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DbTestMonkey.NUnit.Tests", "tests\DbTestMonkey.NUnit.Tests\DbTestMonkey.NUnit.Tests.csproj", "{02566FAF-9F59-4D06-B934-D3B12AAA7E7E}"
+	ProjectSection(ProjectDependencies) = postProject
+		{420DEFA5-E65C-4452-B6A9-40C532B1DAF3} = {420DEFA5-E65C-4452-B6A9-40C532B1DAF3}
+	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NUnitWeaverRunner", "tests\NUnitWeaverRunner\NUnitWeaverRunner.csproj", "{420DEFA5-E65C-4452-B6A9-40C532B1DAF3}"
 EndProject

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 2.0.4.{build}
+version: 2.1.0.{build}
 
 assembly_info:
   patch: true

--- a/src/DbTestMonkey.NUnit.Fody/DbTestMonkey.NUnit.Fody.csproj
+++ b/src/DbTestMonkey.NUnit.Fody/DbTestMonkey.NUnit.Fody.csproj
@@ -46,10 +46,6 @@
       <HintPath>..\..\packages\FodyCecil.1.29.2\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework, Version=3.2.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.3.2.0\lib\net45\nunit.framework.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />

--- a/src/DbTestMonkey.NUnit.Fody/DbTestMonkey.NUnit.Fody.nuspec
+++ b/src/DbTestMonkey.NUnit.Fody/DbTestMonkey.NUnit.Fody.nuspec
@@ -9,25 +9,18 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Fody add-in for weaving database unit testing code.</description>
     <releaseNotes>
-      v2.1.0 - Removed hard compile-time dependency on XUnit.
-      v2.0.1 - ClassDatabaseFixture and CollectionDatabaseFixture now correctly implement IDisposable to allow xUnit to call cleanup code (issue# 16).
-             - Install.ps1 now correctly sets reference CopyLocal to true when false rather than false when true (issue# 15).
-             - Install.ps1 now places the configSections config element before other configuration in app.config (issue# 14).
-             - Fixed SqlLocalDb to require v1.14.0 to avoid the incorrect pull down of v1.6.0 (issue# 13).
-      v2.0.0 - Added support for classes with a static constructor and a single instance constructor.
-      v1.0.0 - First stable release. 
-             - SQL Server Db Provider and XUnit Test Provider are supported.
+      v2.1.0 - First stable release of NUnit adapter. 
     </releaseNotes>    
     <language>en-US</language>
     <projectUrl>https://github.com/DbTestMonkey/DbTestMonkey</projectUrl>
     <licenseUrl>https://github.com/DbTestMonkey/DbTestMonkey/blob/master/License.txt</licenseUrl>
     <copyright>Copyright 2016 Justin Cook. All rights reserved.</copyright>
-    <tags>unit testing database integration xunit fody managed</tags>
+    <tags>unit testing database integration nunit fody managed</tags>
 	<dependencies>
 		<dependency id="Fody" version="1.29.3" />
       <dependency id="DbTestMonkey" version="1.0.0" />
       <dependency id="DbTestMonkey.Contracts" version="1.0.0" />
-      <dependency id="xunit" />
+      <dependency id="NUnit" version="3.2.0" />
 	</dependencies>
   </metadata>
   <files>

--- a/src/DbTestMonkey.NUnit.Fody/ModuleWeaver.cs
+++ b/src/DbTestMonkey.NUnit.Fody/ModuleWeaver.cs
@@ -179,6 +179,31 @@
 
          /*
           * Below instructions create the following line of code:
+          *    Environment.CurrentDirectory = TextContext.CurrentContext.TestDirectory;
+          * */
+         methodDefinition.Body.Instructions.InsertBefore(
+            firstInstruction,
+            Instruction.Create(
+               OpCodes.Call,
+               methodDefinition.Module.ImportReference(
+                  GetTestContextDefinition().Methods.First(m => m.Name == "get_CurrentContext"))));
+
+         methodDefinition.Body.Instructions.InsertBefore(
+            firstInstruction,
+            Instruction.Create(
+               OpCodes.Callvirt,
+               methodDefinition.Module.ImportReference(
+                  GetTestContextDefinition().Methods.First(m => m.Name == "get_TestDirectory"))));
+
+         methodDefinition.Body.Instructions.InsertBefore(
+            firstInstruction,
+            Instruction.Create(
+               OpCodes.Call,
+               methodDefinition.Module.ImportReference(
+                  GetEnvironmentDefinition().Methods.First(m => m.Name == "set_CurrentDirectory"))));
+
+         /*
+          * Below instructions create the following line of code:
           *    DbController.BeforeTestGroup(this.GetType(), new Action<string>(TestContext.WriteLine));
           * */
 
@@ -453,6 +478,20 @@
 
          tearDownMethod.Body.InitLocals = true;
          tearDownMethod.Body.OptimizeMacros();
+      }
+
+      /// <summary>
+      /// Scans the System assembly for the <see cref="Environment"/> type and returns the type definition.
+      /// </summary>
+      /// <returns>A <see cref="TypeDefinition"/> representing the <see cref="Environment"/> class.</returns>
+      /// <exception cref="WeavingException">
+      /// Thrown if no reference to the System assembly was found and the binary itself could not be found either.</exception>
+      private TypeDefinition GetEnvironmentDefinition()
+      {
+         return GetTypeDefinition(
+            "mscorlib",
+            "mscorlib.dll",
+            "System.Environment");
       }
 
       /// <summary>

--- a/src/DbTestMonkey.NUnit.Fody/Properties/AssemblyInfo.cs
+++ b/src/DbTestMonkey.NUnit.Fody/Properties/AssemblyInfo.cs
@@ -6,11 +6,11 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("DbTestMonkey.NUnit.Fody")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
+[assembly: AssemblyDescription("NUnit test provider specific weaving library for DbTestMonkey.")]
+[assembly: AssemblyConfiguration("Release")]
+[assembly: AssemblyCompany("Justin Cook")]
 [assembly: AssemblyProduct("DbTestMonkey.NUnit.Fody")]
-[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyCopyright("Copyright © Justin Cook 2016")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("0.0.0.1")]
+[assembly: AssemblyFileVersion("0.0.0.1")]

--- a/src/DbTestMonkey.NUnit.Fody/build/DbTestMonkey.NUnit.Fody.targets
+++ b/src/DbTestMonkey.NUnit.Fody/build/DbTestMonkey.NUnit.Fody.targets
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <NUnitFrameworkBinaries Include="$(MSBuildThisFileDirectory)..\..\**\nunit.framework.dll"/>
+    <DbTestMonkeyNUnitFodyBinaries Include="$(MSBuildThisFileDirectory)..\lib\net45\*.*"/>
+  </ItemGroup>
+  
+  <Target Name="DbTestMonkeyCopyNUnitBinaries" BeforeTargets="FodyTarget">
+    <Copy SourceFiles="@(NUnitFrameworkBinaries)" DestinationFiles="@(NUnitFrameworkBinaries->'$(ProjectDir)$(IntermediateOutputPath)%(Filename)%(Extension)')" />
+    <Copy SourceFiles="@(DbTestMonkeyNUnitFodyBinaries)" DestinationFolder="$(ProjectDir)$(IntermediateOutputPath)" />
+  </Target>
+</Project>

--- a/src/DbTestMonkey.NUnit.Fody/packages.config
+++ b/src/DbTestMonkey.NUnit.Fody/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="FodyCecil" version="1.29.2" targetFramework="net452" developmentDependency="true" />
-  <package id="NUnit" version="3.2.0" targetFramework="net452" />
 </packages>

--- a/src/DbTestMonkey.Providers.SqlServer/DbTestMonkey.Providers.SqlServer.nuspec
+++ b/src/DbTestMonkey.Providers.SqlServer/DbTestMonkey.Providers.SqlServer.nuspec
@@ -9,6 +9,10 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>SqlServer specific provider for DbTestMonkey.</description>
     <releaseNotes>
+      v2.1.0 - Added ability to define eligible localdb versions in app config to ensure that even with
+               old binaries it would still be possible to spawn up legacy localdb instances for issue# 19.
+             - Reduced brittleness of database deployments by checking whether the physical files had
+               disappeared for a logical instance and then repairing accordingly.
       v2.0.4 - Fixed bug where requesting a connection string from DbTestMonkey via a string property
              - would always give a string back without the requested InitialCatalog set.
       v2.0.3 - Explicitly set the Microsoft.SqlServer.Dac dependency version for issue# 13.

--- a/src/DbTestMonkey.XUnit.Fody/DbTestMonkey.XUnit.Fody.csproj
+++ b/src/DbTestMonkey.XUnit.Fody/DbTestMonkey.XUnit.Fody.csproj
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -57,12 +56,6 @@
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="xunit.abstractions">
-      <HintPath>..\..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
-    </Reference>
-    <Reference Include="xunit.core">
-      <HintPath>..\..\packages\xunit.extensibility.core.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CecilExtensions.cs" />
@@ -94,12 +87,6 @@
     <None Include="Content\FodyWeavers.xml" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props'))" />
-  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/DbTestMonkey.XUnit.Fody/packages.config
+++ b/src/DbTestMonkey.XUnit.Fody/packages.config
@@ -1,9 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="FodyCecil" version="1.29.2" targetFramework="net45" developmentDependency="true" />
-  <package id="xunit" version="2.0.0" targetFramework="net45" developmentDependency="true" />
-  <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.assert" version="2.0.0" targetFramework="net45" developmentDependency="true" />
-  <package id="xunit.core" version="2.0.0" targetFramework="net45" developmentDependency="true" />
-  <package id="xunit.extensibility.core" version="2.0.0" targetFramework="net45" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
Currently the DbTestMonkey solution is failing to build and run unit
tests
due to a dependent project being built after the fact. There is
also an
issue where NUnit >= 3.0 no longer sets the
Environment.CurrentDirectory
which causes DACPAC detection to fail.

The
working directory is now pre-set in the OneTimeSetUp method for NUnit.